### PR TITLE
use common directories for binary and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `snmp_exporter_version` | 0.12.0 | SNMP exporter package version |
+| `snmp_exporter_version` | 0.14.0 | SNMP exporter package version |
 | `snmp_exporter_web_listen_address` | "0.0.0.0:9116" | Address on which SNMP exporter will be listening |
 | `snmp_exporter_config_file` | "" | If this is empty, role will download snmp.yml file from https://github.com/prometheus/snmp_exporter. Otherwise this should contain path to file with custom snmp exporter configuration |
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 import testinfra.utils.ansible_runner
 
@@ -5,16 +6,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_files(host):
-    files = [
-        "/etc/systemd/system/snmp_exporter.service",
-        "/opt/snmp_exporter/snmp_exporter",
-        "/opt/snmp_exporter/snmp.yml"
-    ]
-    for file in files:
-        f = host.file(file)
-        assert f.exists
-        assert f.is_file
+@pytest.mark.parametrize("files", [
+    "/etc/systemd/system/snmp_exporter.service",
+    "/usr/local/bin/snmp_exporter",
+    "/etc/snmp_exporter.yml"
+])
+def test_files(host, files):
+    f = host.file(files)
+    assert f.exists
+    assert f.is_file
 
 
 def test_service(host):

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 @pytest.mark.parametrize("files", [
     "/etc/systemd/system/snmp_exporter.service",
     "/usr/local/bin/snmp_exporter",
-    "/etc/snmp_exporter.yml"
+    "/etc/snmp_exporter/snmp.yml"
 ])
 def test_files(host, files):
     f = host.file(files)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,7 +12,7 @@
 - name: Download snmp configuration file from github repository
   get_url:
     url: "https://raw.githubusercontent.com/prometheus/snmp_exporter/v{{ snmp_exporter_version }}/snmp.yml"
-    dest: /etc/snmp_exporter.yml
+    dest: /etc/snmp_exporter/snmp.yml
     validate_certs: false
     owner: root
     group: root
@@ -23,16 +23,16 @@
   delay: 2
   notify:
     - reload snmp exporter
-  when: snmp_exporter_config_file == ""
+  when: not snmp_exporter_config_file
 
 - name: Copy configuration file
   template:
     src: "{{ snmp_exporter_config_file }}"
-    dest: /etc/snmp_exporter.yml
+    dest: /etc/snmp_exporter/snmp.yml
     owner: root
     group: root
     mode: 0644
   no_log: "{{ 'true' if __testing_on_travis is defined else 'false' }}"
   notify:
     - reload snmp exporter
-  when: snmp_exporter_config_file != ""
+  when: snmp_exporter_config_file

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,38 @@
+---
+- name: Copy the SNMP Exporter systemd service file
+  template:
+    src: snmp_exporter.service.j2
+    dest: /etc/systemd/system/snmp_exporter.service
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart snmp exporter
+
+- name: Download snmp configuration file from github repository
+  get_url:
+    url: "https://raw.githubusercontent.com/prometheus/snmp_exporter/v{{ snmp_exporter_version }}/snmp.yml"
+    dest: /etc/snmp_exporter.yml
+    validate_certs: false
+    owner: root
+    group: root
+    mode: 0644
+  register: _download_config
+  until: _download_config | success
+  retries: 5
+  delay: 2
+  notify:
+    - reload snmp exporter
+  when: snmp_exporter_config_file == ""
+
+- name: Copy configuration file
+  template:
+    src: "{{ snmp_exporter_config_file }}"
+    dest: /etc/snmp_exporter.yml
+    owner: root
+    group: root
+    mode: 0644
+  no_log: "{{ 'true' if __testing_on_travis is defined else 'false' }}"
+  notify:
+    - reload snmp exporter
+  when: snmp_exporter_config_file != ""

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,30 @@
+---
+- name: Download snmp_exporter binary to local folder
+  become: false
+  get_url:
+    url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    dest: "/tmp"
+    checksum: "sha256:{{ snmp_exporter_checksum }}"
+  register: _download_binary
+  until: _download_binary | success
+  retries: 5
+  delay: 2
+  delegate_to: localhost
+  check_mode: false
+
+- name: Unpack snmp_exporter binary
+  become: false
+  unarchive:
+    src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    dest: "/tmp"
+    creates: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
+  delegate_to: localhost
+  check_mode: false
+
+- name: Propagate SNMP Exporter binaries
+  copy:
+    src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
+    dest: "/usr/local/bin/snmp_exporter"
+    mode: 0755
+  notify:
+    - restart snmp exporter

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,3 +28,11 @@
     mode: 0755
   notify:
     - restart snmp exporter
+
+- name: Create configuration directory
+  file:
+    path: "/etc/snmp_exporter"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,86 +1,26 @@
 ---
-- name: Create directory
-  file:
-    dest: /opt/snmp_exporter
-    state: directory
+- include: preflight.yml
+  tags:
+    - snmp_exporter_install
+    - snmp_exporter_configure
+    - snmp_exporter_run
 
-- name: "Get checksum for {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }} architecture"
-  set_fact:
-    snmp_exporter_checksum: "{{ item.split(' ')[0] }}"
-  with_items:
-    - "{{ lookup('url', 'https://github.com/prometheus/snmp_exporter/releases/download/v' + snmp_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
-  when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"
+- include: install.yml
+  become: true
+  tags:
+    - snmp_exporter_install
 
-- name: Download snmp_exporter binary to local folder
-  become: false
-  get_url:
-    url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    checksum: "sha256:{{ snmp_exporter_checksum }}"
-  register: _download_binary
-  until: _download_binary | success
-  retries: 5
-  delay: 2
-  delegate_to: localhost
-  check_mode: false
+- include: configure.yml
+  become: true
+  tags:
+    - snmp_exporter_configure
 
-- name: Unpack snmp_exporter binary
-  become: false
-  unarchive:
-    src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    creates: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
-  delegate_to: localhost
-  check_mode: false
-
-- name: Propagate SNMP Exporter binaries
-  copy:
-    src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
-    dest: "/opt/snmp_exporter"
-    mode: 0755
-  notify:
-    - restart snmp exporter
-
-- name: Copy the SNMP Exporter systemd service file
-  template:
-    src: snmp_exporter.service.j2
-    dest: /etc/systemd/system/snmp_exporter.service
-    owner: root
-    group: root
-    mode: 0644
-  notify:
-    - restart snmp exporter
-
-- name: Download snmp configuration file from github repository
-  get_url:
-    url: "https://raw.githubusercontent.com/prometheus/snmp_exporter/v{{ snmp_exporter_version }}/snmp.yml"
-    dest: /opt/snmp_exporter/snmp.yml
-    validate_certs: false
-    owner: root
-    group: root
-    mode: 0644
-  register: _download_config
-  until: _download_config | success
-  retries: 5
-  delay: 2
-  notify:
-    - reload snmp exporter
-  when: not snmp_exporter_config_file
-
-- name: Copy configuration file
-  template:
-    src: "{{ snmp_exporter_config_file }}"
-    dest: /opt/snmp_exporter/snmp.yml
-    owner: root
-    group: root
-    mode: 0644
-  no_log: "{{ 'true' if __testing_on_travis is defined else 'false' }}"
-  notify:
-    - reload snmp exporter
-  when: snmp_exporter_config_file
-
-- name: Ensure SNMP Exporter is enabled on boot
+- name: ensure snmp_exporter service is started and enabled
+  become: true
   systemd:
     daemon_reload: true
     name: snmp_exporter
+    state: started
     enabled: true
+  tags:
+    - snmp_exporter_run

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,0 +1,7 @@
+---
+- name: "Get checksum for {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }} architecture"
+  set_fact:
+    snmp_exporter_checksum: "{{ item.split(' ')[0] }}"
+  with_items:
+    - "{{ lookup('url', 'https://github.com/prometheus/snmp_exporter/releases/download/v' + snmp_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+  when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"

--- a/templates/snmp_exporter.service.j2
+++ b/templates/snmp_exporter.service.j2
@@ -10,7 +10,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/snmp_exporter \
   --web.listen-address={{ snmp_exporter_web_listen_address }} \
   --log.level={{ snmp_exporter_log_level }} \
-  --config.file=/etc/snmp_exporter.yml
+  --config.file=/etc/snmp_exporter/snmp.yml
 
 KillMode=process
 

--- a/templates/snmp_exporter.service.j2
+++ b/templates/snmp_exporter.service.j2
@@ -7,10 +7,10 @@ Type=simple
 User=nobody
 Group={{ 'nogroup' if ansible_os_family == 'Debian' else 'nobody' }}
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/opt/snmp_exporter/snmp_exporter \
+ExecStart=/usr/local/bin/snmp_exporter \
   --web.listen-address={{ snmp_exporter_web_listen_address }} \
   --log.level={{ snmp_exporter_log_level }} \
-  --config.file=/opt/snmp_exporter/snmp.yml
+  --config.file=/etc/snmp_exporter.yml
 
 KillMode=process
 


### PR DESCRIPTION
Port changes from other @cloudalchemy roles:

- always install binary in `/usr/local/bin`
- always use `/etc/snmp_exporter.yml` as a confguration file
- split tasks/main.yml into multiple files
- add tags support
- fix readme after previous release

Merging this PR will create a new [minor] release.