### PR TITLE
make installation work without internet access

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `snmp_exporter_version` | 0.19.0 | SNMP exporter package version |
+| `snmp_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `snmp_exporter` binary is stored on host on which ansible is ran. This overrides `snmp_exporter_version` parameter |
 | `snmp_exporter_web_listen_address` | "0.0.0.0:9116" | Address on which SNMP exporter will be listening |
 | `snmp_exporter_config_file` | "" | If this is empty, role will download snmp.yml file from https://github.com/prometheus/snmp_exporter. Otherwise this should contain path to file with custom snmp exporter configuration |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 snmp_exporter_version: 0.19.0
+snmp_exporter_binary_local_dir: ''
 snmp_exporter_web_listen_address: "0.0.0.0:9116"
 snmp_exporter_log_level: info
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,31 +1,42 @@
 ---
-- name: Download snmp_exporter binary to local folder
-  become: false
-  get_url:
-    url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    checksum: "sha256:{{ snmp_exporter_checksum }}"
-  register: _download_binary
-  until: _download_binary is success
-  retries: 5
-  delay: 2
-  delegate_to: localhost
-  check_mode: false
+- block:
+    - name: Download snmp_exporter binary to local folder
+      become: false
+      get_url:
+        url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+        dest: "/tmp"
+        checksum: "sha256:{{ snmp_exporter_checksum }}"
+      register: _download_binary
+      until: _download_binary is success
+      retries: 5
+      delay: 2
+      delegate_to: localhost
+      check_mode: false
 
-- name: Unpack snmp_exporter binary
-  become: false
-  unarchive:
-    src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    creates: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
-  delegate_to: localhost
-  check_mode: false
+    - name: Unpack snmp_exporter binary
+      become: false
+      unarchive:
+        src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
+      delegate_to: localhost
+      check_mode: false
 
-- name: Propagate SNMP Exporter binaries
+    - name: Propagate SNMP Exporter binary
+      copy:
+        src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
+        dest: "/usr/local/bin/snmp_exporter"
+        mode: 0755
+      notify:
+        - restart snmp exporter
+  when: snmp_exporter_binary_local_dir | length == 0
+
+- name: Propagate locally distributed SNMP Exporter binary
   copy:
-    src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
+    src: "{{ snmp_exporter_binary_local_dir }}/snmp_exporter"
     dest: "/usr/local/bin/snmp_exporter"
     mode: 0755
+  when: snmp_exporter_binary_local_dir | length > 0
   notify:
     - restart snmp exporter
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,7 +1,17 @@
 ---
-- name: "Get checksum for {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }} architecture"
+- name: Get checksum lookup parameters
   set_fact:
-    snmp_exporter_checksum: "{{ item.split(' ')[0] }}"
-  with_items:
-    - "{{ lookup('url', 'https://github.com/prometheus/snmp_exporter/releases/download/v' + snmp_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
-  when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"
+    snmp_exporter_checksum_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+    snmp_exporter_checksum_url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"
+
+- name: "Get checksum for {{ snmp_exporter_checksum_arch }} architecture"
+  set_fact:
+    snmp_exporter_checksum: "{{ lookup('url', snmp_exporter_checksum_url, wantlist=True) | list | \
+                              select('contains', 'linux-' + snmp_exporter_checksum_arch + '.tar.gz') | list | first).split(' ')[0] }}"
+  ignore_errors: true
+  register: snmp_exporter_checksum_lookup
+
+- name: Checksum lookup error message
+  fail:
+    msg: "Could not find a checksum for 'linux-{{ snmp_exporter_checksum_arch }}.tar.gz' in '{{ snmp_exporter_checksum_url }}'"
+  when: snmp_exporter_checksum_lookup.failed

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,17 +1,19 @@
 ---
-- name: Get checksum lookup parameters
-  set_fact:
-    snmp_exporter_checksum_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
-    snmp_exporter_checksum_url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"
+- block:
+    - name: Get checksum lookup parameters
+      set_fact:
+        snmp_exporter_checksum_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+        snmp_exporter_checksum_url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"
 
-- name: "Get checksum for {{ snmp_exporter_checksum_arch }} architecture"
-  set_fact:
-    snmp_exporter_checksum: "{{ lookup('url', snmp_exporter_checksum_url, wantlist=True) | list | \
-                              select('contains', 'linux-' + snmp_exporter_checksum_arch + '.tar.gz') | list | first).split(' ')[0] }}"
-  ignore_errors: true
-  register: snmp_exporter_checksum_lookup
+    - name: "Get checksum for {{ snmp_exporter_checksum_arch }} architecture"
+      set_fact:
+        snmp_exporter_checksum: "{{ lookup('url', snmp_exporter_checksum_url, wantlist=True) | list | \
+                                  select('contains', 'linux-' + snmp_exporter_checksum_arch + '.tar.gz') | list | first).split(' ')[0] }}"
+      ignore_errors: true
+      register: snmp_exporter_checksum_lookup
 
-- name: Checksum lookup error message
-  fail:
-    msg: "Could not find a checksum for 'linux-{{ snmp_exporter_checksum_arch }}.tar.gz' in '{{ snmp_exporter_checksum_url }}'"
-  when: snmp_exporter_checksum_lookup.failed
+    - name: Checksum lookup error message
+      fail:
+        msg: "Could not find a checksum for 'linux-{{ snmp_exporter_checksum_arch }}.tar.gz' in '{{ snmp_exporter_checksum_url }}'"
+      when: snmp_exporter_checksum_lookup.failed
+  when: snmp_exporter_binary_local_dir | length == 0


### PR DESCRIPTION
* reworked the checksum lookup mechanism to not cause errors when the ansible host doesn't have an internet connection
* added local binary dir option, same as https://github.com/cloudalchemy/ansible-blackbox-exporter/pull/79